### PR TITLE
[add] 検索結果なしの場合のエラーを解消

### DIFF
--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -37,6 +37,14 @@ class SearchService
         $dummyData->created_at = '検索結果がありません';
         $dummyData->updated_at = '検索結果がありません';
         $this->emptyTrivium->push($dummyData);
+
+        // ダミー用のインスタンスをLengthAwarePaginatorにする
+        $this->emptyTrivium = new LengthAwarePaginator(
+            $this->emptyTrivium,
+            $this->emptyTrivium->count(),
+            5,
+            1
+        );
     }
 
     public function search(): LengthAwarePaginator


### PR DESCRIPTION
検索結果なしの場合、従来はCollection型インスタンスをダミーデータとしてSearchServiceで返していた。
これが型ヒントの「LengthAwarePaginator」の指定と合わずエラーが出ていたため、
ダミーデータの型変換を行い、LengthAwarePaginatorを返すようにした。
バグ解消確認。