### PR TITLE
[fix] バリデーションにより、新規投稿ができなくなるバグを解消

### DIFF
--- a/app/Http/Controllers/HomeModeController.php
+++ b/app/Http/Controllers/HomeModeController.php
@@ -86,8 +86,8 @@ class HomeModeController extends Controller
         // バリデーション
         $request->validate([
             'title' => 'required|max:255',
-            'summary' => 'required|max:255',
-            'detail' => 'required|max:255',
+            'summary' => 'required',
+            'detail' => 'required',
         ]);
 
         // モデルを使って、DBに保存する値をセット


### PR DESCRIPTION
バリデーションで255文字制限になっていたため、新規投稿ができなかった。
すでに撤廃した。