### PR TITLE
Succeed message file name change

### DIFF
--- a/resources/views/components/succeed_message.blade.php
+++ b/resources/views/components/succeed_message.blade.php
@@ -1,5 +1,4 @@
-<!-- インポート成功時のメッセージ -->
-
+<!-- 成功時のメッセージ -->
 @if (session('flash_succeed_message'))
     <div class="import_succeed_container">
         <div class="message">

--- a/resources/views/home_mode/exported_files.blade.php
+++ b/resources/views/home_mode/exported_files.blade.php
@@ -39,7 +39,7 @@
 
             @endcomponent
 
-            @component('components.import_succeed')
+            @component('components.succeed_message')
 
             @endcomponent
         </main>

--- a/resources/views/home_mode/index.blade.php
+++ b/resources/views/home_mode/index.blade.php
@@ -59,7 +59,7 @@
 
 @endcomponent
 
-@component('components.import_succeed')
+@component('components.succeed_message')
 
 @endcomponent
 

--- a/resources/views/pseudo_page/form.blade.php
+++ b/resources/views/pseudo_page/form.blade.php
@@ -36,7 +36,7 @@
     <input type="submit" value="送信">
 </form>
 
-@component('components.import_succeed')
+@component('components.succeed_message')
 @endcomponent
 
 @endsection

--- a/resources/views/soft_delete/index.blade.php
+++ b/resources/views/soft_delete/index.blade.php
@@ -39,8 +39,8 @@
 
         @endcomponent
 
-        @component('components.import_succeed')
-
+        @component('components.succeed_message')
+        
         @endcomponent
         </main>
 </html>

--- a/resources/views/temp/index.blade.php
+++ b/resources/views/temp/index.blade.php
@@ -39,7 +39,7 @@
 
             @endcomponent
 
-            @component('components.import_succeed')
+            @component('components.succeed_message')
 
             @endcomponent
         </main>


### PR DESCRIPTION
成功時に表示されるメッセージのコンポーネントが、インポート限定であるかのように放置されていたため改名した。